### PR TITLE
Create automatically generated API python reference using mkdocstrings

### DIFF
--- a/aerosim-data/python/aerosim_data/middleware.py
+++ b/aerosim-data/python/aerosim_data/middleware.py
@@ -8,6 +8,7 @@ Metadata = middleware.Metadata
 BincodeSerializer = middleware.BincodeSerializer
 
 class Singleton(type):
+    """Singleton type."""
     _instances = {}
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
@@ -23,6 +24,7 @@ def get_transport(transport):
 
 
 class BaseMiddleware(metaclass=Singleton):
+    """Base metaclass for middleware"""
     def __init__(self, transport, serializer):
         self._transport = transport
         self._serializer = serializer

--- a/aerosim-data/python/aerosim_data/utils.py
+++ b/aerosim-data/python/aerosim_data/utils.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 
 
-def dict_to_namespace(d):
+def dict_to_namespace(d: dict):
     """Convert a dictionary to a SimpleNamespace, handling nested dictionaries."""
     for key, value in d.items():
         if isinstance(value, dict):
@@ -10,6 +10,7 @@ def dict_to_namespace(d):
 
 
 def flatten_to_dict(dict_or_namespace: dict | SimpleNamespace):
+    """Flatten a dictionary or a SimpleNamespace."""
     flat_dict = {}
 
     def flatten(d, parent_key=""):

--- a/aerosim-dynamics-models/python/aerosim_dynamics_models/evtol_effectors_fmu_model.py
+++ b/aerosim-dynamics-models/python/aerosim_dynamics_models/evtol_effectors_fmu_model.py
@@ -70,6 +70,7 @@ class effector:
 
 # Note: The class name is used as the FMU file name
 class evtol_effectors_fmu_model(Fmi3Slave):
+    """EVTOL Effector FMU model."""
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/aerosim-dynamics-models/python/aerosim_dynamics_models/jsbsim_dynamics_fmu_model.py
+++ b/aerosim-dynamics-models/python/aerosim_dynamics_models/jsbsim_dynamics_fmu_model.py
@@ -18,6 +18,7 @@ from pythonfmu3 import Fmi3Slave
 
 # Note: The class name is used as the FMU file name
 class jsbsim_dynamics_fmu_model(Fmi3Slave):
+    """JSBIM dynamics FMU model."""
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/aerosim-dynamics-models/python/aerosim_dynamics_models/jsbsim_standalone_fmu_model.py
+++ b/aerosim-dynamics-models/python/aerosim_dynamics_models/jsbsim_standalone_fmu_model.py
@@ -17,6 +17,7 @@ from pythonfmu3 import Fmi3Slave
 
 # Note: The class name is used as the FMU file name
 class jsbsim_standalone_fmu_model(Fmi3Slave):
+    """JSBIM standalone FMU model.`"""
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/aerosim-dynamics-models/python/aerosim_dynamics_models/rotor_effector_fmu_model.py
+++ b/aerosim-dynamics-models/python/aerosim_dynamics_models/rotor_effector_fmu_model.py
@@ -13,6 +13,7 @@ from pythonfmu3 import Fmi3Slave
 
 # Note: The class name is used as the FMU file name
 class rotor_effector_fmu_model(Fmi3Slave):
+    """Rotor effector FMU model."""
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/aerosim-dynamics-models/python/aerosim_dynamics_models/trajectory_follower_fmu_model.py
+++ b/aerosim-dynamics-models/python/aerosim_dynamics_models/trajectory_follower_fmu_model.py
@@ -12,6 +12,7 @@ from pythonfmu3 import Fmi3Slave
 
 # Note: The class name is used as the FMU file name
 class trajectory_follower_fmu_model(Fmi3Slave):
+    """Trajectory follower FMU model."""
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/docs/api_aerosim.md
+++ b/docs/api_aerosim.md
@@ -1,0 +1,3 @@
+# Aerosim API Reference
+
+::: aerosim

--- a/docs/api_aerosim_data.md
+++ b/docs/api_aerosim_data.md
@@ -1,0 +1,6 @@
+# AeroSim Data
+
+The `aerosim-data` module provides various types and interfaces to be used across the AeroSim project according to the AeroSim Data design. The module includes examples to illustrate its usage.
+
+::: aerosim-data.python.aerosim_data
+::: aerosim-data.python.aerosim_data.middleware

--- a/docs/api_daa.md
+++ b/docs/api_daa.md
@@ -1,0 +1,1 @@
+::: examples.autopilot_daa_scenario

--- a/docs/api_dynamics_models.md
+++ b/docs/api_dynamics_models.md
@@ -1,0 +1,10 @@
+# Dynamics models
+
+Modules with dynamics models specifications used to build FMU files.
+All these classes inherit from the `pythonfmu3.Fmi3Slave` class, from the [pythonfmu3](https://pypi.org/project/pythonfmu3/) package, which enables to build co-simulation FMUs with python.
+
+::: aerosim-dynamics-models.python.aerosim_dynamics_models.evtol_effectors_fmu_model
+::: aerosim-dynamics-models.python.aerosim_dynamics_models.jsbsim_dynamics_fmu_model
+::: aerosim-dynamics-models.python.aerosim_dynamics_models.jsbsim_standalone_fmu_model
+::: aerosim-dynamics-models.python.aerosim_dynamics_models.rotor_effector_fmu_model
+::: aerosim-dynamics-models.python.aerosim_dynamics_models.trajectory_follower_fmu_model

--- a/docs/api_first_flight.md
+++ b/docs/api_first_flight.md
@@ -1,0 +1,1 @@
+::: examples.first_flight

--- a/docs/api_pilot.md
+++ b/docs/api_pilot.md
@@ -1,0 +1,1 @@
+::: examples.pilot_control_with_flight_deck

--- a/docs/api_simulink.md
+++ b/docs/api_simulink.md
@@ -1,0 +1,1 @@
+::: examples.simulink_cosim_and_fmu

--- a/docs/css/mkdocstrings.css
+++ b/docs/css/mkdocstrings.css
@@ -1,0 +1,5 @@
+/* Indentation. */
+div.doc-contents:not(.first) {
+    padding-left: 25px;
+    border-left: .05rem solid rgba(200, 200, 200, 0.2);
+}

--- a/examples/autopilot_daa_scenario.py
+++ b/examples/autopilot_daa_scenario.py
@@ -1,9 +1,9 @@
 """
-Autopilot DAA (Detect and Avoid) Scenario Example
+# Autopilot DAA (Detect and Avoid) Scenario Example
 
 This example demonstrates how to use the aerosim package to:
-1. Run a simulation with autopilot following predefined waypoints
-2. Stream camera images and flight data to aerosim-app
+    1. Run a simulation with autopilot following predefined waypoints
+    2. Stream camera images and flight data to aerosim-app
 
 This example loads waypoints from a file, configures the simulation,
 and runs the autopilot in waypoint-following mode.
@@ -19,13 +19,11 @@ Usage:
     aircraft to simulate a potential DAA situation. With the AeroSim App window
     active you can take manual control to avoid a collision by using an Xbox
     controller:
-        
-        - "B" button activates manual control
 
+        - "B" button activates manual control
         In hover mode (low speed):
             - Left stick controls yaw and altitude
             - Right stick controls forward speed and lateral speed  
-        
         In forward flight mode (high speed):
             - Left stick controls pitch and yaw
             - Right stick controls forward speed and roll

--- a/examples/first_flight.py
+++ b/examples/first_flight.py
@@ -1,23 +1,28 @@
 """
-First Flight with App Example
+# First Flight with App Example
 
 This example demonstrates how to use the aerosim package to:
-1. Run a simulation with WebSockets support for communication with aerosim-app
-2. Process input commands from aerosim-app
-3. Stream camera images and flight data to aerosim-app
+    1. Run a simulation with WebSockets support for communication with aerosim-app
+    2. Process input commands from aerosim-app
+    3. Stream camera images and flight data to aerosim-app
 
 This is a simplified example that shows the core functionality of the aerosim package.
 
 Usage:
-    # Run from the aerosim root directory:
+    Run from the aerosim root directory:
+    ```
     python examples/first_flight.py
+    ```
 
-    # Or run from the examples directory:
+    Or run from the examples directory:
+    ```
     cd examples
     python first_flight.py
+    ```
 
     The airplane will take off under autopilot control, but with the AeroSim App window active you 
     can use the keyboard to adjust the autopilot setpoints:
+    
         - "Up arrow" key increases airspeed setpoint (non-zero setpoint sets throttle to 100%)
         - "Down arrow" key decreases airspeed setpoint (zero setpoint sets throttle to 0%)
         - "W" key increases altitude setpoint (ascend)

--- a/examples/pilot_control_with_flight_deck.py
+++ b/examples/pilot_control_with_flight_deck.py
@@ -1,17 +1,17 @@
 """
-Pilot Control with Flight Deck Example
+# Pilot Control with Flight Deck Example
 
 This example demonstrates how to run a simulation to fly an airplane with a
 flight deck in three modes:
-  1. Joystick direct control of flight control surfaces (Xbox controller mapping)
-  2. Keyboard control of autopilot setpoints (airspeed, altitude, heading)
-  3. Autopilot control by flight plan waypoints (example_flight_plan.json)
+    1. Joystick direct control of flight control surfaces (Xbox controller mapping)
+    2. Keyboard control of autopilot setpoints (airspeed, altitude, heading)
+    3. Autopilot control by flight plan waypoints (example_flight_plan.json)
 
 Usage:
     cd examples
     python pilot_control_with_flight_deck.py
 
-    Enter "1", "2", or "3" to choose the control mode from the options listed above.
+    Enter `1`, `2`, or `3` to choose the control mode from the options listed above.
     Use keyboard or joystick inputs with the AeroSim App window active:
         
         For mode 1 using an Xbox controller

--- a/examples/simulink_cosim_and_fmu.py
+++ b/examples/simulink_cosim_and_fmu.py
@@ -1,9 +1,9 @@
 """
-Simulink Co-Simulation and FMU Example
+# Simulink Co-Simulation and FMU Example
 
 This example demonstrates how to use the aerosim package to:
-1. Run a simulation that co-simulates with Simulink
-2. Stream camera images to aerosim-app
+    1. Run a simulation that co-simulates with Simulink
+    2. Stream camera images to aerosim-app
 
 This example shows how to integrate AeroSim with Simulink models
 for advanced control and simulation capabilities.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,6 @@ docs_dir: docs
 edit_uri: 'edit/master/docs/'
 theme: readthedocs
   
-
 nav:
 - Home: 'index.md'
 - Overview: 'overview.md'
@@ -26,4 +25,33 @@ nav:
   - Scene graph: 'scene_graph_reference.md'
   - Simulink integration: 'simulink_integration.md'
   - SimReady asset creation: 'usd_asset_pipeline.md'
-  
+- API reference:
+  - AeroSim: 'api_aerosim.md'
+  - Scripts:
+    - First flight: 'api_first_flight.md'
+    - Autpilot DAA scenario: 'api_daa.md'
+    - Pilot control with fly deck: 'api_pilot.md'
+    - Simulink co-simulation and FMU: 'api_simulink.md'
+  - AeroSim data: 'api_aerosim_data.md'
+  - Dynamics models: 'api_dynamics_models.md'
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            show_source: false
+            docstring_style: google
+            annotations_path: brief
+            show_signature: true
+            separate_signature: true
+            show_root_toc_entry: false
+            show_root_members_full_path: false
+            merge_init_into_class: true
+            filters:
+              - "!^_"
+
+extra_css:
+- css/mkdocstrings.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev-dependencies = [
     "opencv-python>=4.11.0.86",
     "numpy>=2.2.3",
     "black>=25.1.0",
+    "mkdocstrings-python>=1.16.10",
 ]
 
 [tool.rye.workspace]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -60,6 +60,7 @@ cloudpickle==3.1.1
     # via dask
 colorama==0.4.6
     # via click
+    # via griffe
     # via ipython
     # via mkdocs
     # via pytest
@@ -107,6 +108,8 @@ fsspec==2024.12.0
     # via dask
 ghp-import==2.1.0
     # via mkdocs
+griffe==1.7.2
+    # via mkdocstrings-python
 h11==0.14.0
     # via httpcore
 httpcore==1.0.7
@@ -139,6 +142,7 @@ jinja2==3.1.5
     # via jupyterlab
     # via jupyterlab-server
     # via mkdocs
+    # via mkdocstrings
     # via nbconvert
 jsbsim==1.2.1
     # via aerosim-controllers
@@ -198,9 +202,14 @@ lz4==4.4.3
     # via mcap
 markdown==3.7
     # via mkdocs
+    # via mkdocs-autorefs
+    # via mkdocstrings
+    # via pymdown-extensions
 markupsafe==3.0.2
     # via jinja2
     # via mkdocs
+    # via mkdocs-autorefs
+    # via mkdocstrings
     # via nbconvert
     # via werkzeug
 matplotlib==3.10.0
@@ -220,8 +229,16 @@ mergedeep==1.3.4
 mistune==3.1.0
     # via nbconvert
 mkdocs==1.6.1
+    # via mkdocs-autorefs
+    # via mkdocstrings
+mkdocs-autorefs==1.4.1
+    # via mkdocstrings
+    # via mkdocstrings-python
 mkdocs-get-deps==0.2.0
     # via mkdocs
+mkdocstrings==0.29.1
+    # via mkdocstrings-python
+mkdocstrings-python==1.16.10
 msgpack==1.1.0
     # via fmpy
 mypy-extensions==1.0.0
@@ -307,6 +324,8 @@ pygame==2.6.1
 pygments==2.19.1
     # via ipython
     # via nbconvert
+pymdown-extensions==10.14.3
+    # via mkdocstrings
 pyparsing==3.2.1
     # via matplotlib
 pyqtgraph==0.13.7
@@ -342,6 +361,7 @@ pyyaml==6.0.2
     # via jupyter-events
     # via mkdocs
     # via mkdocs-get-deps
+    # via pymdown-extensions
     # via pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs


### PR DESCRIPTION
Create automatically generated API python documentation using mkdocstrings. This mkdocs extension makes use of docstrings and type annotations in python classes and functions to parse them and automatically generate a documentation.

Styling could be further improved using custom CSS. Also, more docstrings should be included/enhanced in different modules to improve this documentation.

- [ ] Docs for Aerosim python module
- [ ] Docs for 4 main python examples
- [ ] Docs for aerosim-core
- [ ] Docs for aerosim-data
- [ ] Docs for aerosim-dynamics-models
- [ ] Docs for aerosim-sensors
- [ ] Docs for aerosim-world
- [ ] Improve docstrings in general

Some of the above modules may not require an API documentation.

Here are some examples:

![431829533-7d3df778-3ad6-4b87-8e07-243ace3af269](https://github.com/user-attachments/assets/c6909f1e-8825-4c31-a71c-6c2579c241e0)

![431829573-ce57c7b5-9f7a-4a39-9104-41e2f2d7b9e3](https://github.com/user-attachments/assets/49aa8c73-b3e0-4160-a647-c96603de2093)
