### PR TITLE
Enhance messages and data types documentation

### DIFF
--- a/aerosim/src/aerosim/core/config.py
+++ b/aerosim/src/aerosim/core/config.py
@@ -6,7 +6,7 @@ This module provides utilities for loading, validating, and managing simulation 
 
 import os
 import json
-from typing import Dict, Any, Optional, List, Union
+from typing import Dict, Any, Optional, List
 
 
 class SimConfig:

--- a/aerosim/src/aerosim/io/input/base.py
+++ b/aerosim/src/aerosim/io/input/base.py
@@ -4,7 +4,7 @@ Base input handler for AeroSim.
 This module provides the base class for handling input from various sources.
 """
 
-from typing import Dict, Any, Callable, Optional
+from typing import Callable, Optional
 
 
 class InputHandler:

--- a/aerosim/src/aerosim/io/input/keyboard.py
+++ b/aerosim/src/aerosim/io/input/keyboard.py
@@ -5,7 +5,7 @@ This module provides utilities for handling keyboard input.
 """
 
 import pygame
-from typing import Dict, Any, Callable, Optional, Tuple
+from typing import Callable, Optional
 
 from .base import InputHandler
 

--- a/aerosim/src/aerosim/io/websockets/__init__.py
+++ b/aerosim/src/aerosim/io/websockets/__init__.py
@@ -5,7 +5,7 @@ This module provides standardized WebSockets servers for communication with aero
 """
 
 import asyncio
-from typing import List, Dict, Any, Set, Callable, Optional
+from typing import List, Callable, Optional
 import os
 
 from .command_server import start_command_server

--- a/aerosim/src/aerosim/io/websockets/image_server.py
+++ b/aerosim/src/aerosim/io/websockets/image_server.py
@@ -7,10 +7,9 @@ This module provides a WebSocket server for streaming camera images to aerosim-a
 import asyncio
 import traceback
 import base64
-import time
 import numpy as np
 import cv2
-from typing import Set, Dict, Any, Optional, Callable, Deque
+from typing import Set, Optional, Callable, Deque
 from collections import deque
 from websockets import WebSocketServerProtocol
 import websockets

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -18,6 +18,9 @@ This page documents the message and data type structures for the topics used by 
 * [PrimaryFlightDisplayData](#primaryflightdisplaydata)
 * [Quaternion](#quaternion)
 * [TimeStamp](#timestamp)
+* [TrajectoryVisualization](#trajectoryvisualization)
+* [TrajectoryVisualizationSettings](#trajectoryvisualizationsettings)
+* [TrajectoryWaypoints](#trajectorywaypoints)
 * [Vector3](#vector3)
 * [VehicleState](#vehiclestate)
 
@@ -162,7 +165,7 @@ Fields:
 
 ## Image
 
-Data type for encoding images. Can be converted through the `compress` method to a `CompressedImage`.
+Data type for encoding images. Can be converted through the `compress` method to a [`CompressedImage`](#compressedimage).
 
 Fields:
 
@@ -202,6 +205,8 @@ Generic data type to encode json data.
 Fields:
 
 * `data`: `String` - data to be encoded as json.
+
+---
 
 ## Pose
 
@@ -258,6 +263,40 @@ Fields:
 
 * `sec`: `int32` - Simulation time in seconds.
 * `nanosec`: `uint32` - Simulation time in nanoseconds beyond the given time in seconds.
+
+---
+
+## TrajectoryVisualization
+
+Aircraft Trajectory Visualization Command.
+
+Fields:
+
+* `settings`: [`TrajectoryVisualizationSettings`](#trajectoryvisualizationsettings) - Settings of the trajectory visualization.
+* `user_defined_waypoints`: [`TrajectoryWaypoints`](#trajectorywaypoints) - User defined waypoints.
+* `future_trajectory`: [`TrajectoryWaypoints`](#trajectorywaypoints) - Future waypoints of the trajectory.
+
+---
+
+## TrajectoryVisualizationSettings
+
+Settings fot the [`TrajectoryVisualization`](#trajectoryvisualization) messages.
+
+Fields:
+
+* `display_future_trajectory`: `bool` - Whether to display future trajectory points.
+* `display_past_trajectory`: `bool` - Whether to display past trajectory points.
+* `highlight_user_defined_waypoints`: `bool` - Whether to highlight those waypoints set by the user.
+* `number_of_future_waypoints`: `u64` - Indicates the number of waypoints in the future trajectory.
+---
+
+## TrajectoryWaypoints
+
+Indicate the waypoints of a trajectory by a string.
+
+Fields:
+
+* `waypoints`: `String` - string with waypoints of the trajectory.
 
 ---
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -6,13 +6,17 @@ This page documents the message and data type structures for the topics used by 
 * [ActorState](#actorstate)
 * [AircraftEffectorCommand](#aircrafteffectorcommand)
 * [AutopilotCommand](#autopilotcommand)
+* [AutopilotFlightPlanCommand](#autopilotflightplancommand)
 * [CameraInfo](#camerainfo)
 * [CompressedImage](#compressedimage)
 * [EffectorState](#effectorstate)
 * [FlightControlCommand](#flightcontrolcommand)
 * [GNSS](#gnss)
 * [Header](#header)
+* [HSIMode](#hsimode)
 * [Image](#image)
+* [ImageEncoding](#imageencoding)
+* [ImageFormat](#imageformat)
 * [IMU](#imu)
 * [JsonData](#jsondata)
 * [PhysicalProperties](#physicalproperties)
@@ -75,10 +79,7 @@ Input to autopilot.
 Fields:
 
 * `flight_plan`: `String` - Flight plan information, e.g. waypoints, mission, etc.
-* `flight_plan_command`: [`AutopilotFlightPlanCommand`](#autopilotflightplancommand) - Flight plan execution command:
-    - `Stop` = 0
-    - `Run` = 1
-    - `Pause` = 2
+* `flight_plan_command`: [`AutopilotFlightPlanCommand`](#autopilotflightplancommand) - Flight plan execution command: `Stop`, `Run` or `Pause`.
 * `use_manual_setpoints`: `bool` - Flag to use manual setpoints instead of flight plan.
 * `attitude_hold`: `bool` - Flag to hold current attitude roll/pitch/yaw if True.
 * `altitude_setpoint_ft`: `f64` - Target hold altitude in feet.
@@ -89,6 +90,18 @@ Fields:
 * `heading_setpoint_deg`: `f64` - Target heading setpoint in degrees (0 = north, 90 = east, 180 = south, 270 = west).
 * `target_wp_latitude_deg`: `f64` - Target waypoint latitude in degrees.
 * `target_wp_longitude_deg`: `f64` - Target waypoint longitude in degrees.
+
+---
+
+## AutopilotFlightPlanCommand
+
+Enum with the different commands for the autopilot flight plan.
+
+Fields:
+
+- `Stop` = 0
+- `Run` = 1
+- `Pause` = 2
 
 ---
 
@@ -114,9 +127,7 @@ Compressed images from the [`Image`](#image) data type using [turbojpeg](https:/
 
 Fields:
 
-* `format`: `ImageFormat` - Format of the image:
-    - `JPEG`
-    - `PNG`
+* `format`: [`ImageFormat`](#imageformat) - Format of the image, either `JPEG` or `PNG`.
 * `data`: `Vec<u8>` - Image data.
 
 ---
@@ -176,6 +187,18 @@ Fields:
 
 ---
 
+## HSIMode
+
+Enum with different available HSI modes for the [`PrimaryFlightDisplayData`](#primaryflightdisplaydata).
+
+Fields:
+
+- `GPS` = 0
+- `VOR1` = 1
+- `VOR2` = 2
+
+---
+
 ## Image
 
 Data type for encoding images. Can be converted through the `compress` method to a [`CompressedImage`](#compressedimage).
@@ -185,17 +208,37 @@ Fields:
 * `camera_info`: [`CameraInfo`](#camerainfo) - Information of the camera source.
 * `height`: `u32` - Height of the image.
 * `width`: `u32` - Width of the image.
-* `encoding`: `ImageEncoding` - Type of enconding of the image:
-    - `RGB8`
-    - `RGBA8`
-    - `BGR8`
-    - `BGRA8`
-    - `MONO8`
-    - `MONO16`
-    - `YUV422`
+* `encoding`: [`ImageEncoding`](#imageencoding) - Type of enconding of the image.
 * `is_bigendian`: `u8` - Whether it is big endian or not (order of bytes encoding).
 * `step`: `u32`
 * `data`: `Vec<u8>` - Image data as a sequence of integers.
+
+---
+
+## ImageEncoding
+
+Enunm with image encoding available options.
+
+Fields:
+
+- `RGB8`
+- `RGBA8`
+- `BGR8`
+- `BGRA8`
+- `MONO8`
+- `MONO16`
+- `YUV422`
+
+---
+
+## ImageFormat
+
+Enum indicating the format of a [`CompressedImage`](#compressedimage).
+
+Fields:
+
+- `JPEG`
+- `PNG`
 
 ---
 
@@ -262,10 +305,7 @@ Fields:
 * `heading_deg`: `f64` - JSBSim `attitude/heading-true-rad` converted to deg.
 * `hsi_course_select_heading_deg`: `f64` - For GPS mode, calculated heading between prev and next waypoints.
 * `hsi_course_deviation_deg`: `f64` - For GPS mode, nautical mile offset from course line converted as 5 NM = 12 deg.
-* `hsi_mode`: `HSIMode` - User-set mode, start with GPS only:
-    - `GPS` = 0
-    - `VOR1` = 1
-    - `VOR2` = 2
+* `hsi_mode`: [`HSIMode`](#hsimode) - User-set mode, start with GPS only. Available options: `GPS`, `VOR1` and `VOR2`.
 
 ---
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -8,6 +8,7 @@ This page documents the message and data type structures for the topics used by 
 * [CameraInfo](#camerainfo)
 * [CompressedImage](#compressedimage)
 * [FlightControlCommand](#flightcontrolcommand)
+* [Header](#header)
 * [Image](#image)
 * [Pose](#pose)
 * [PrimaryFlightDisplayData](#primaryflightdisplaydata)
@@ -24,7 +25,7 @@ Data type with generic actor information.
 
 Fields:
 
-* `pose`: `Pose` - Actor pose
+* `pose`: `Pose` - Actor pose.
 
 ---
 
@@ -36,14 +37,14 @@ Fields:
 
 * `throttle_cmd`: `Vec<f64>` - Engine throttle command. Scales between 0.0 (no power) and 1.0 (max power). Values are provided in an array for multiple thrust-generating devices.
 * `aileron_cmd_angle_rad`: `Vec<f64>` - Aileron deflection command in radians.
-* `elevator_cmd_angle_rad`: `Vec<f64>` - Elevator deflection command in radians..
-* `rudder_cmd_angle_rad`: `Vec<f64>` - Rudder deflection command in radians..
-* `thrust_tilt_cmd_angle_rad`: `Vec<f64>` - Thrust tilt command in radians..
+* `elevator_cmd_angle_rad`: `Vec<f64>` - Elevator deflection command in radians.
+* `rudder_cmd_angle_rad`: `Vec<f64>` - Rudder deflection command in radians.
+* `thrust_tilt_cmd_angle_rad`: `Vec<f64>` - Thrust tilt command in radians.
 * `flap_cmd_angle_rad`: `Vec<f64>` -  Flap angle in radians.
-* `speedbrake_cmd_angle_rad`: `Vec<f64>` - Speedbrake angle in radians
-* `landing_gear_cmd`: `Vec<f64>` - Landing gear, 0.0 stowed, 1.0 deployed
-* `wheel_steer_cmd_angle_rad`: `Vec<f64>` - Wheel steer angle radians
-* `wheel_brake_cmd`: `Vec<f64>` - Wheel brake command, 1.0 fully applied, 0.0 no brake
+* `speedbrake_cmd_angle_rad`: `Vec<f64>` - Speedbrake angle in radians.
+* `landing_gear_cmd`: `Vec<f64>` - Landing gear, 0.0 stowed, 1.0 deployed.
+* `wheel_steer_cmd_angle_rad`: `Vec<f64>` - Wheel steer angle radians.
+* `wheel_brake_cmd`: `Vec<f64>` - Wheel brake command, 1.0 fully applied, 0.0 no brake.
 
 ---
 
@@ -58,16 +59,16 @@ Fields:
     - `Stop` = 0
     - `Run` = 1
     - `Pause` = 2
-* `use_manual_setpoints`: `bool` - Flag to use manual setpoints instead of flight plan
-* `attitude_hold`: `bool` - Flag to hold current attitude roll/pitch/yaw if True
-* `altitude_setpoint_ft`: `f64` - Target hold altitude in feet
-* `airspeed_hold`: `bool` - Flag to hold airspeed if True
-* `airspeed_setpoint_kts`: `f64` - Target hold airspeed in knots
-* `heading_hold`: `bool` - Flag to hold heading if True
-* `heading_set_by_waypoint`: `bool` - Flag to use waypoint as target heading instead of heading_setpoint if True
-* `heading_setpoint_deg`: `f64` - Target heading setpoint in degrees (0 = north, 90 = east, 180 = south, 270 = west)
-* `target_wp_latitude_deg`: `f64` - Target waypoint latitude in degrees
-* `target_wp_longitude_deg`: `f64` - Target waypoint longitude in degrees
+* `use_manual_setpoints`: `bool` - Flag to use manual setpoints instead of flight plan.
+* `attitude_hold`: `bool` - Flag to hold current attitude roll/pitch/yaw if True.
+* `altitude_setpoint_ft`: `f64` - Target hold altitude in feet.
+* `airspeed_hold`: `bool` - Flag to hold airspeed if True.
+* `airspeed_setpoint_kts`: `f64` - Target hold airspeed in knots.
+* `heading_hold`: `bool` - Flag to hold heading if True.
+* `heading_set_by_waypoint`: `bool` - Flag to use waypoint as target heading instead of heading_setpoint if True.
+* `heading_setpoint_deg`: `f64` - Target heading setpoint in degrees (0 = north, 90 = east, 180 = south, 270 = west).
+* `target_wp_latitude_deg`: `f64` - Target waypoint latitude in degrees.
+* `target_wp_longitude_deg`: `f64` - Target waypoint longitude in degrees.
 
 ---
 
@@ -77,13 +78,13 @@ Data type with information about the camera settings.
 
 Fields:
 
-* `width`: `u32` - Width of the camera
-* `height`: `u32` - Height of the camera
-* `distortion_model`: `String` - Distortion model assumed in the camera
-* `d`: `Vec<f64>` - Camera parameter *d*
-* `k`: `[f64; 9]` - Camera parameter *k*
-* `r`: `[f64; 9]` - Camera parameter *r*
-* `p`: `[f64; 12]` - Camera parameter *p*
+* `width`: `u32` - Width of the camera.
+* `height`: `u32` - Height of the camera.
+* `distortion_model`: `String` - Distortion model assumed in the camera.
+* `d`: `Vec<f64>` - Camera parameter *d*.
+* `k`: `[f64; 9]` - Camera parameter *k*.
+* `r`: `[f64; 9]` - Camera parameter *r*.
+* `p`: `[f64; 12]` - Camera parameter *p*.
 
 ---
 
@@ -94,7 +95,7 @@ Compressed images from the `Image` data type using [turbojpeg](https://docs.rs/t
 Fields:
 
 * `format`: `ImageFormat` - Format of the image, `JPEG` or `PNG`.
-* `data`: `Vec<u8>` - Image data
+* `data`: `Vec<u8>` - Image data.
 
 ---
 
@@ -105,15 +106,27 @@ Data type used as input to a flight controller, got as output from (auto)pilot.
 Fields:
 
 * `power_cmd`: `Vec<f64>` - Vehicle power command. Scales between 0.0 (no power) and 1.0 (max power). Values are provided in an array for multiple thrust-generating devices.
-* `roll_cmd`: `f64` - Vehicle roll command. Scales between -1.0 and 1.0
-* `pitch_cmd`: `f64` - Vehicle pitch command. Scales between -1.0 and 1.0
-* `yaw_cmd`: `f64` - Vehicle yaw command. Scales between -1.0 and 1.0
-* `thrust_tilt_cmd`: `f64` - Tilt command for a tilt-rotor craft. Scales between 0.0 and 1.0
-* `flap_cmd`: `f64` - Flap state command. Scales between 0.0 and 1.0
-* `speedbrake_cmd`: `f64` - Speed brake command. Scales between 0.0 and 1.0
-* `landing_gear_cmd`: `f64` - Landing gear command. Scales between 0.0 (stowed) amd 1.0 (extended)
-* `wheel_steer_cmd`: `f64` - Wheel steer for taxi. Scales between -1.0 (left) and 1.0 (right)
-* `wheel_brake_cmd`: `f64` - Wheel brake command. Scales between 0.0 (off) and 1.0 (full strength)
+* `roll_cmd`: `f64` - Vehicle roll command. Scales between -1.0 and 1.0.
+* `pitch_cmd`: `f64` - Vehicle pitch command. Scales between -1.0 and 1.0.
+* `yaw_cmd`: `f64` - Vehicle yaw command. Scales between -1.0 and 1.0.
+* `thrust_tilt_cmd`: `f64` - Tilt command for a tilt-rotor craft. Scales between 0.0 and 1.0.
+* `flap_cmd`: `f64` - Flap state command. Scales between 0.0 and 1.0.
+* `speedbrake_cmd`: `f64` - Speed brake command. Scales between 0.0 and 1.0.
+* `landing_gear_cmd`: `f64` - Landing gear command. Scales between 0.0 (stowed) amd 1.0 (extended).
+* `wheel_steer_cmd`: `f64` - Wheel steer for taxi. Scales between -1.0 (left) and 1.0 (right).
+* `wheel_brake_cmd`: `f64` - Wheel brake command. Scales between 0.0 (off) and 1.0 (full strength).
+
+---
+
+## Header
+
+Header present in all messages.
+
+Fields:
+
+* `timestamp_sim`: `TimeStamp` - Discrete simulation time. A sentinel value `{sec: i32::MIN, nanosec: 0}` is set when the simulation time is not specified.
+* `timestamp_platform`: `TimeStamp` - Absolute platform time since the Unix Epoch.
+* `frame_id`: `String` - Identifier for the frame.
 
 ---
 
@@ -123,9 +136,9 @@ Data type for encoding images. Can be converted through the `compress` method to
 
 Fields:
 
-* `camera_info`: `CameraInfo` - Information of the camera source
-* `height`: `u32` - Height of the image
-* `width`: `u32` - Width of the image 
+* `camera_info`: `CameraInfo` - Information of the camera source.
+* `height`: `u32` - Height of the image.
+* `width`: `u32` - Width of the image.
 * `encoding`: `ImageEncoding` - Type of enconding of the image:
     - `RGB8`
     - `RGBA8`
@@ -134,9 +147,9 @@ Fields:
     - `MONO8`
     - `MONO16`
     - `YUV422`
-* `is_bigendian`: `u8` - Whether it is big endian or not (order of bytes encoding)
+* `is_bigendian`: `u8` - Whether it is big endian or not (order of bytes encoding).
 * `step`: `u32`
-* `data`: `Vec<u8>` - Image data as a sequence of integers
+* `data`: `Vec<u8>` - Image data as a sequence of integers.
 
 ---
 
@@ -146,8 +159,8 @@ Data type with position and orientation information of an actor.
 
 Fields:
 
-* `position`: `Vector3` - Actor 3D position
-* `orientation`: `Quaternion` - Actor quaternion orientation
+* `position`: `Vector3` - Actor 3D position.
+* `orientation`: `Quaternion` - Actor quaternion orientation.
 
 ---
 
@@ -157,18 +170,18 @@ Flight data to be displayed in the deck's Primary Flight Display (PFD) component
 
 Fields:
 
-* `airspeed_kts`: `f64` - JSBSim `velocities/vc-kts`
-* `true_airspeed_kts`: `f64` - JSBSim `velocities/vtrue-kts`
-* `altitude_ft`: `f64` - JSBSim `position/h-sl-ft`
-* `target_altitude_ft`: `f64` - AutopilotCommand `altitude_setpoint_ft`
-* `altimeter_pressure_setting_inhg`: `f64` - User-set value (standard pressure = 29.92 inHG, QNH = height above MSL adjusted from local atmospheric pressure, QFE = height above airfield elevation)
-* `vertical_speed_fpm`: `f64` - JSBSim `velocities/h-dot-fps` converted to feet/min
-* `pitch_deg`: `f64` - JSBSim `attitude/pitch-rad`
-* `roll_deg`: `f64` - JSBSim `attitude/roll-rad`
-* `side_slip_fps2`: `f64` - JSBSim `accelerations/vdot-ft_sec2`
-* `heading_deg`: `f64` - JSBSim `attitude/heading-true-rad` converted to deg
-* `hsi_course_select_heading_deg`: `f64` - For GPS mode, calculated heading between prev and next waypoints
-* `hsi_course_deviation_deg`: `f64` - For GPS mode, nautical mile offset from course line converted as 5 NM = 12 deg
+* `airspeed_kts`: `f64` - JSBSim `velocities/vc-kts`.
+* `true_airspeed_kts`: `f64` - JSBSim `velocities/vtrue-kts`.
+* `altitude_ft`: `f64` - JSBSim `position/h-sl-ft`.
+* `target_altitude_ft`: `f64` - AutopilotCommand `altitude_setpoint_ft`.
+* `altimeter_pressure_setting_inhg`: `f64` - User-set value (standard pressure = 29.92 inHG, QNH = height above MSL adjusted from local atmospheric pressure, QFE = height above airfield elevation).
+* `vertical_speed_fpm`: `f64` - JSBSim `velocities/h-dot-fps` converted to feet/min.
+* `pitch_deg`: `f64` - JSBSim `attitude/pitch-rad`.
+* `roll_deg`: `f64` - JSBSim `attitude/roll-rad`.
+* `side_slip_fps2`: `f64` - JSBSim `accelerations/vdot-ft_sec2`.
+* `heading_deg`: `f64` - JSBSim `attitude/heading-true-rad` converted to deg.
+* `hsi_course_select_heading_deg`: `f64` - For GPS mode, calculated heading between prev and next waypoints.
+* `hsi_course_deviation_deg`: `f64` - For GPS mode, nautical mile offset from course line converted as 5 NM = 12 deg.
 * `hsi_mode`: `HSIMode` - User-set mode, start with GPS only:
     - `GPS` = 0
     - `VOR1` = 1
@@ -180,10 +193,10 @@ Fields:
 
 Quaternion data type.
 
-* `w`: `f64` - Scalar component
-* `x`: `f64` - x coordinate
-* `y`: `f64` - y coordinate
-* `z`: `f64` - z coordinate
+* `w`: `f64` - Scalar component.
+* `x`: `f64` - x coordinate.
+* `y`: `f64` - y coordinate.
+* `z`: `f64` - z coordinate.
 
 ---
 
@@ -193,18 +206,18 @@ Data type containing a simulator time stamp.
 
 Fields:
 
-* `sec`: `int32` - Simulation time in seconds
-* `nanosec`: `uint32` - Simulation time in nanoseconds beyond the given time in seconds
+* `sec`: `int32` - Simulation time in seconds.
+* `nanosec`: `uint32` - Simulation time in nanoseconds beyond the given time in seconds.
 
 ---
 
 ## Vector3
 
-Generic vector 3D data type
+Generic vector 3D data type.
 
-* `x`: `f64` - x coordinate
-* `y`: `f64` - y coordinate
-* `z`: `f64` - z coordinate
+* `x`: `f64` - x coordinate.
+* `y`: `f64` - y coordinate.
+* `z`: `f64` - z coordinate.
 
 ---
 
@@ -214,8 +227,8 @@ Data type containing information about the vehicle state, including pose, veloci
 
 Fields:
 
-* `state`: `ActorState` - Combined actor state information
-* `velocity`: `Vector3` - Actor velocity in m/s
-* `angular_velocity`: `Vector3` - Actor angular velocity in rad/s
-* `acceleration`: `Vector3` - Actor acceleration in m/s<sup>2</sup>
-* `angular_acceleration`: `Vector3` - Actor angular acceleration in rad/s<sup>2</sup>
+* `state`: `ActorState` - Combined actor state information.
+* `velocity`: `Vector3` - Actor velocity in m/s.
+* `angular_velocity`: `Vector3` - Actor angular velocity in rad/s.
+* `acceleration`: `Vector3` - Actor acceleration in m/s<sup>2</sup>.
+* `angular_acceleration`: `Vector3` - Actor angular acceleration in rad/s<sup>2</sup>.

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -8,7 +8,9 @@ This page documents the message and data type structures for the topics used by 
 * [CompressedImage](#compressedimage)
 * [FlightControlCommand](#flightcontrolcommand)
 * [Pose](#pose)
+* [Quaternion](#quaternion)
 * [TimeStamp](#timestamp)
+* [Vector3](#vector3)
 * [VehicleState](#vehiclestate)
 
 ---
@@ -27,33 +29,33 @@ Fields:
 
 Fields:
 
-* `throttle_cmd`: *Vec&lt;f64&gt;* - engine throttle command. Scales between 0.0 (no power) and 1.0 (max power). Values are provided in an array for multiple thrust-generating devices.
-* `aileron_cmd_angle_rad`: *Vec&lt;f64&gt;* - aileron deflection command in radians.
-* `elevator_cmd_angle_rad`: *Vec&lt;f64&gt;* - elevator deflection command in radians..
-* `rudder_cmd_angle_rad`: *Vec&lt;f64&gt;* - rudder deflection command in radians..
-* `thrust_tilt_cmd_angle_rad`: *Vec&lt;f64&gt;* - thrust tilt command in radians..
-* `flap_cmd_angle_rad`: *Vec&lt;f64&gt;* -  flap angle in radians.
-* `speedbrake_cmd_angle_rad`: *Vec&lt;f64&gt;* - speedbrake angle in radians
-* `landing_gear_cmd`: *Vec&lt;f64&gt;* - landing gear, 0.0 stowed, 1.0 deployed
-* `wheel_steer_cmd_angle_rad`: *Vec&lt;f64&gt;* - wheel steer angle radians
-* `wheel_brake_cmd`: *Vec&lt;f64&gt;* - wheel brake command, 1.0 fully applied, 0.0 no brake
+* `throttle_cmd`: `Vec<f64>` - Engine throttle command. Scales between 0.0 (no power) and 1.0 (max power). Values are provided in an array for multiple thrust-generating devices.
+* `aileron_cmd_angle_rad`: `Vec<f64>` - Aileron deflection command in radians.
+* `elevator_cmd_angle_rad`: `Vec<f64>` - Elevator deflection command in radians..
+* `rudder_cmd_angle_rad`: `Vec<f64>` - Rudder deflection command in radians..
+* `thrust_tilt_cmd_angle_rad`: `Vec<f64>` - Thrust tilt command in radians..
+* `flap_cmd_angle_rad`: `Vec<f64>` -  Flap angle in radians.
+* `speedbrake_cmd_angle_rad`: `Vec<f64>` - Speedbrake angle in radians
+* `landing_gear_cmd`: `Vec<f64>` - Landing gear, 0.0 stowed, 1.0 deployed
+* `wheel_steer_cmd_angle_rad`: `Vec<f64>` - Wheel steer angle radians
+* `wheel_brake_cmd`: `Vec<f64>` - Wheel brake command, 1.0 fully applied, 0.0 no brake
 
 ---
 
 ## AutopilotCommand
 
-* `flight_plan`: *String*
-* `flight_plan_command`: *AutopilotFlightPlanCommand*
-* `use_manual_setpoints`: *bool*
-* `attitude_hold`: *bool* - True (hold altitude) or False
-* `altitude_setpoint_ft`: *f64* - target hold altitude
-* `airspeed_hold`: *bool* - True (hold airspeed) or False
-* `airspeed_setpoint_kts`: *f64* - target hold airspeed
-* `heading_hold`: *bool* - True (hold heading) or False
-* `heading_set_by_waypoint`: *bool* - True (use waypoint) or False
-* `heading_setpoint_deg`: *f64* - target heading in degrees
-* `target_wp_latitude_deg`: *f64* - target waypoint latitude
-* `target_wp_longitude_deg`: *f64* - target waypoint longitude
+* `flight_plan`: `string`
+* `flight_plan_command`: `AutopilotFlightPlanCommand`
+* `use_manual_setpoints`: `bool`
+* `attitude_hold`: `bool` - True (hold altitude) or False
+* `altitude_setpoint_ft`: `f64` - Target hold altitude
+* `airspeed_hold`: `bool` - True (hold airspeed) or False
+* `airspeed_setpoint_kts`: `f64` - Target hold airspeed
+* `heading_hold`: `bool` - True (hold heading) or False
+* `heading_set_by_waypoint`: `bool` - True (use waypoint) or False
+* `heading_setpoint_deg`: `f64` - Target heading in degrees
+* `target_wp_latitude_deg`: `f64` - Target waypoint latitude
+* `target_wp_longitude_deg`: `f64` - Target waypoint longitude
 
 ---
 
@@ -64,8 +66,8 @@ Data type enconding images from rendered with compression.
 Fields:
 
 * `header`: *aerosim_data/msg/Header* - Message header with timeStamp and frame ID information
-* `height`: *uint32* - Height of the image 
-* `width`: *uint32* - Width of the image
+* `height`: `uint32` - Height of the image 
+* `width`: `uint32` - Width of the image
 * `format`: *string* - Format of the image
 * `data`: *sequence<uint8>* - Image data as a sequence of integers
 
@@ -77,16 +79,16 @@ Data type used as input to a flight controller, got as output from (auto)pilot.
 
 Fields:
 
-* `power_cmd`: *Vec&lt;f64&gt;* - vehicle power command. Scales between 0.0 (no power) and 1.0 (max power). Values are provided in an array for multiple thrust-generating devices.
-* `roll_cmd`: *f64* - vehicle roll command. Scales between -1.0 and 1.0
-* `pitch_cmd`: *f64* - vehicle pitch command. Scales between -1.0 and 1.0
-* `yaw_cmd`: *f64* - vehicle yaw command. Scales between -1.0 and 1.0
-* `thrust_tilt_cmd`: *f64* - tilt command for a tilt-rotor craft. Scales between 0.0 and 1.0
-* `flap_cmd`: *f64* - flap state command. Scales between 0.0 and 1.0
-* `speedbrake_cmd`: *f64* - speed brake command. Scales between 0.0 and 1.0
-* `landing_gear_cmd`: *f64* - landing gear command. Scales between 0.0 (stowed) amd 1.0 (extended)
-* `wheel_steer_cmd`: *f64* - wheel steer for taxi. Scales between -1.0 (left) and 1.0 (right)
-* `wheel_brake_cmd`: *f64* - wheel brake command. Scales between 0.0 (off) and 1.0 (full strength)
+* `power_cmd`: `Vec<f64>` - Vehicle power command. Scales between 0.0 (no power) and 1.0 (max power). Values are provided in an array for multiple thrust-generating devices.
+* `roll_cmd`: `f64` - Vehicle roll command. Scales between -1.0 and 1.0
+* `pitch_cmd`: `f64` - Vehicle pitch command. Scales between -1.0 and 1.0
+* `yaw_cmd`: `f64` - Vehicle yaw command. Scales between -1.0 and 1.0
+* `thrust_tilt_cmd`: `f64` - Tilt command for a tilt-rotor craft. Scales between 0.0 and 1.0
+* `flap_cmd`: `f64` - Flap state command. Scales between 0.0 and 1.0
+* `speedbrake_cmd`: `f64` - Speed brake command. Scales between 0.0 and 1.0
+* `landing_gear_cmd`: `f64` - Landing gear command. Scales between 0.0 (stowed) amd 1.0 (extended)
+* `wheel_steer_cmd`: `f64` - Wheel steer for taxi. Scales between -1.0 (left) and 1.0 (right)
+* `wheel_brake_cmd`: `f64` - Wheel brake command. Scales between 0.0 (off) and 1.0 (full strength)
 
 ---
 
@@ -101,14 +103,35 @@ Fields:
 
 ---
 
+## Quaternion
+
+Quaternion data type.
+
+* `w`: `f64` - Scalar component
+* `x`: `f64` - x coordinate
+* `y`: `f64` - y coordinate
+* `z`: `f64` - z coordinate
+
+---
+
 ## TimeStamp
 
 Data type containing a simulator time stamp.
 
 Fields:
 
-* `sec`: *int32* - simulation time in seconds
-* `nanosec`: *uint32* - simulation time in nanoseconds beyond the given time in seconds
+* `sec`: `int32` - Simulation time in seconds
+* `nanosec`: `uint32` - Simulation time in nanoseconds beyond the given time in seconds
+
+---
+
+## Vector3
+
+Generic vector 3D data type
+
+* `x`: `f64` - x coordinate
+* `y`: `f64` - y coordinate
+* `z`: `f64` - z coordinate
 
 ---
 
@@ -118,22 +141,8 @@ Data type containing information about the vehicle state, including pose, veloci
 
 Fields:
 
-* `state`: *ActorState* - combined actor state information
-    * `pose`: *Pose* - actor pose
-        * `header`: *Header* - header containing ancilliary information
-            * `stamp`: *TimeStamp*
-                * `sec`: *int32*
-                * `nanosec`: *uint32*
-            * `frame_id`: *String* - simulation frame ID
-        * `position`: *Vector3* - position in meters
-            * `x`, `y`, `z`
-        * `orientation`: *Quaternion* - orientation, using quaternion notation
-            * `w`, `x`, `y`, `z`
-* `velocity`: *Vector3* actor velocity in m/s
-    * `x`, `y`, `z`
-* `angular_velocity`: *Vector3* - actor angular velocity in rad/s
-    * `x`, `y`, `z`
-* `acceleration`: *Vector3* - actor acceleration in m/s<sup>2</sup>
-    * `x`, `y`, `z`
-* `angular_acceleration`: *Vector3* - actor angular acceleration in rad/s<sup>2</sup>
-    * `x`, `y`, `z`
+* `state`: `ActorState` - Combined actor state information
+* `velocity`: `Vector3` - Actor velocity in m/s
+* `angular_velocity`: `Vector3` - Actor angular velocity in rad/s
+* `acceleration`: `Vector3` - Actor acceleration in m/s<sup>2</sup>
+* `angular_acceleration`: `Vector3` - Actor angular acceleration in rad/s<sup>2</sup>

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -2,6 +2,7 @@
 
 This page documents the message and data type structures for the topics used by the components of AeroSim to exchange data. See the [aerosim-data](https://github.com/aerosim-open/aerosim/tree/main/aerosim-data) module for more information.
 
+* [ActorModel](#actormodel)
 * [ActorState](#actorstate)
 * [AircraftEffectorCommand](#aircrafteffectorcommand)
 * [AutopilotCommand](#autopilotcommand)
@@ -14,6 +15,7 @@ This page documents the message and data type structures for the topics used by 
 * [Image](#image)
 * [IMU](#imu)
 * [JsonData](#jsondata)
+* [PhysicalProperties](#physicalproperties)
 * [Pose](#pose)
 * [PrimaryFlightDisplayData](#primaryflightdisplaydata)
 * [Quaternion](#quaternion)
@@ -23,6 +25,17 @@ This page documents the message and data type structures for the topics used by 
 * [TrajectoryWaypoints](#trajectorywaypoints)
 * [Vector3](#vector3)
 * [VehicleState](#vehiclestate)
+
+---
+
+## ActorModel
+
+Data type specifying the asset and physical properties of an actor.
+
+Fields:
+
+* `physical_properties`: [`PhysicalProperties`](#physicalproperties) - Physical properties of the actor.
+* `asset_link`: `Option<String>` - Link to the asset of the actor.
 
 ---
 
@@ -205,6 +218,18 @@ Generic data type to encode json data.
 Fields:
 
 * `data`: `String` - data to be encoded as json.
+
+---
+
+## PhysicalProperties
+
+Physical properties of an actor.
+
+Fields:
+
+* `mass`: `f64` - Mass of the actor.
+* `inertia_tensor`: [`Vector3`](#vector3) - Inertia tensor of the actor, indicated as a vector.
+* `moment_of_inertia`: [`Vector3`](#vector3) - Moment of inertia of the actor.
 
 ---
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -106,3 +106,17 @@ Fields:
 * `Stop` = 0
 * `Run` = 1
 * `Pause` = 2
+
+---
+
+## CompressedImage
+
+Data type enconding images from rendered with compression.
+
+Fields:
+
+* `header`: *aerosim_data/msg/Header* - Message header with timeStamp and frame ID information
+* `height`: *uint32* - Height of the image 
+* `width`: *uint32* - Width of the image
+* `format`: *string* - Format of the image
+* `data`: *sequence<uint8>* - Image data as a sequence of integers

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -7,9 +7,13 @@ This page documents the message and data type structures for the topics used by 
 * [AutopilotCommand](#autopilotcommand)
 * [CameraInfo](#camerainfo)
 * [CompressedImage](#compressedimage)
+* [EffectorState](#effectorstate)
 * [FlightControlCommand](#flightcontrolcommand)
+* [GNSS](#gnss)
 * [Header](#header)
 * [Image](#image)
+* [IMU](#imu)
+* [JsonData](#jsondata)
 * [Pose](#pose)
 * [PrimaryFlightDisplayData](#primaryflightdisplaydata)
 * [Quaternion](#quaternion)
@@ -25,7 +29,7 @@ Data type with generic actor information.
 
 Fields:
 
-* `pose`: `Pose` - Actor pose.
+* `pose`: [`Pose`](#pose) - Actor pose.
 
 ---
 
@@ -55,7 +59,7 @@ Input to autopilot.
 Fields:
 
 * `flight_plan`: `String` - Flight plan information, e.g. waypoints, mission, etc.
-* `flight_plan_command`: `AutopilotFlightPlanCommand` - Flight plan execution command:
+* `flight_plan_command`: [`AutopilotFlightPlanCommand`](#autopilotflightplancommand) - Flight plan execution command:
     - `Stop` = 0
     - `Run` = 1
     - `Pause` = 2
@@ -90,11 +94,13 @@ Fields:
 
 ## CompressedImage
 
-Compressed images from the `Image` data type using [turbojpeg](https://docs.rs/turbojpeg/latest/turbojpeg/) via the method `compress`. Can be decompress to an `Image` type through the `decompress` method. Dimensions of the image are encoded in the compression.
+Compressed images from the [`Image`](#image) data type using [turbojpeg](https://docs.rs/turbojpeg/latest/turbojpeg/) via the method `compress`. Can be decompress to an [`Image`](#image) type through the `decompress` method. Dimensions of the image are encoded in the compression.
 
 Fields:
 
-* `format`: `ImageFormat` - Format of the image, `JPEG` or `PNG`.
+* `format`: `ImageFormat` - Format of the image:
+    - `JPEG`
+    - `PNG`
 * `data`: `Vec<u8>` - Image data.
 
 ---
@@ -105,7 +111,7 @@ Data type with effector state information, used in the FMU models definition.
 
 Fields:
 
-* `pose`: `Pose` - Actor pose.
+* `pose`: [`Pose`](#pose) - Actor pose.
 
 ---
 
@@ -137,7 +143,7 @@ Fields:
 * `latitude`: `f64` - Data latitude.
 * `longitude`: `f64` - Data longitude.
 * `altitude`: `f64` - Data altitude.
-* `velocity`: `Vector3` - 3D velocity.
+* `velocity`: [`Vector3`](#vector3) - 3D velocity.
 * `heading`: `f64` - Heading.
 
 ---
@@ -148,8 +154,8 @@ Header present in all messages.
 
 Fields:
 
-* `timestamp_sim`: `TimeStamp` - Discrete simulation time. A sentinel value `{sec: i32::MIN, nanosec: 0}` is set when the simulation time is not specified.
-* `timestamp_platform`: `TimeStamp` - Absolute platform time since the Unix Epoch.
+* `timestamp_sim`: [`TimeStamp`](#timestamp) - Discrete simulation time. A sentinel value `{sec: i32::MIN, nanosec: 0}` is set when the simulation time is not specified.
+* `timestamp_platform`: [`TimeStamp`](#timestamp) - Absolute platform time since the Unix Epoch.
 * `frame_id`: `String` - Identifier for the frame.
 
 ---
@@ -160,7 +166,7 @@ Data type for encoding images. Can be converted through the `compress` method to
 
 Fields:
 
-* `camera_info`: `CameraInfo` - Information of the camera source.
+* `camera_info`: [`CameraInfo`](#camerainfo) - Information of the camera source.
 * `height`: `u32` - Height of the image.
 * `width`: `u32` - Width of the image.
 * `encoding`: `ImageEncoding` - Type of enconding of the image:
@@ -183,9 +189,9 @@ IMU sensor messages.
 
 Fields:
 
-* `acceleration`: `Vector3` - Acceleration data.
-* `gyroscope`: `Vector3` - Gyroscope data, with angular velocity information.
-* `magnetic_field`: `Vector3` - Magnetic field data.
+* `acceleration`: [`Vector3`](#vector3) - Acceleration data.
+* `gyroscope`: [`Vector3`](#vector3) - Gyroscope data, with angular velocity information.
+* `magnetic_field`: [`Vector3`](#vector3) - Magnetic field data.
 
 ---
 
@@ -203,8 +209,8 @@ Data type with position and orientation information of an actor.
 
 Fields:
 
-* `position`: `Vector3` - Actor 3D position.
-* `orientation`: `Quaternion` - Actor quaternion orientation.
+* `position`: [`Vector3`](#vector3) - Actor 3D position.
+* `orientation`: [`Quaternion`](#quaternion) - Actor quaternion orientation.
 
 ---
 
@@ -271,8 +277,8 @@ Data type containing information about the vehicle state, including pose, veloci
 
 Fields:
 
-* `state`: `ActorState` - Combined actor state information.
-* `velocity`: `Vector3` - Actor velocity in m/s.
-* `angular_velocity`: `Vector3` - Actor angular velocity in rad/s.
-* `acceleration`: `Vector3` - Actor acceleration in m/s<sup>2</sup>.
-* `angular_acceleration`: `Vector3` - Actor angular acceleration in rad/s<sup>2</sup>.
+* `state`: [`ActorState`](#actorstate) - Combined actor state information.
+* `velocity`: [`Vector3`](#vector3) - Actor velocity in m/s.
+* `angular_velocity`: [`Vector3`](#vector3) - Actor angular velocity in rad/s.
+* `acceleration`: [`Vector3`](#vector3) - Actor acceleration in m/s<sup>2</sup>.
+* `angular_acceleration`: [`Vector3`](#vector3) - Actor angular acceleration in rad/s<sup>2</sup>.

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -5,6 +5,7 @@ This page documents the message and data type structures for the topics used by 
 * [ActorState](#actorstate)
 * [AirCraftEffectorCommand](#aircrafteffectorcommand)
 * [AutopilotCommand](#autopilotcommand)
+* [CameraInfo](#camerainfo)
 * [CompressedImage](#compressedimage)
 * [FlightControlCommand](#flightcontrolcommand)
 * [Image](#image)
@@ -66,13 +67,13 @@ Data type with information about the camera settings.
 
 Fields:
 
-* `width`: `u32`
-* `height`: `u32`
-* `distortion_model`: `String`
-* `d`: `Vec<f64>`
-* `k`: `[f64; 9]`
-* `r`: `[f64; 9]`
-* `p`: `[f64; 12]`
+* `width`: `u32` - Width of the camera
+* `height`: `u32` - Height of the camera
+* `distortion_model`: `String` - Distortion model assumed in the camera
+* `d`: `Vec<f64>` - Distortion parameter *d*
+* `k`: `[f64; 9]` - Distortion parameter *k*
+* `r`: `[f64; 9]` - Distortion parameter *r*
+* `p`: `[f64; 12]` - Distortion parameter *p*
 
 ---
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -99,6 +99,16 @@ Fields:
 
 ---
 
+## EffectorState
+
+Data type with effector state information, used in the FMU models definition.
+
+Fields:
+
+* `pose`: `Pose` - Actor pose.
+
+---
+
 ## FlightControlCommand
 
 Data type used as input to a flight controller, got as output from (auto)pilot.
@@ -115,6 +125,20 @@ Fields:
 * `landing_gear_cmd`: `f64` - Landing gear command. Scales between 0.0 (stowed) amd 1.0 (extended).
 * `wheel_steer_cmd`: `f64` - Wheel steer for taxi. Scales between -1.0 (left) and 1.0 (right).
 * `wheel_brake_cmd`: `f64` - Wheel brake command. Scales between 0.0 (off) and 1.0 (full strength).
+
+---
+
+## GNSS
+
+GNSS message.
+
+Fields:
+
+* `latitude`: `f64` - Data latitude.
+* `longitude`: `f64` - Data longitude.
+* `altitude`: `f64` - Data altitude.
+* `velocity`: `Vector3` - 3D velocity.
+* `heading`: `f64` - Heading.
 
 ---
 
@@ -152,6 +176,26 @@ Fields:
 * `data`: `Vec<u8>` - Image data as a sequence of integers.
 
 ---
+
+## IMU
+
+IMU sensor messages.
+
+Fields:
+
+* `acceleration`: `Vector3` - Acceleration data.
+* `gyroscope`: `Vector3` - Gyroscope data, with angular velocity information.
+* `magnetic_field`: `Vector3` - Magnetic field data.
+
+---
+
+## JsonData
+
+Generic data type to encode json data.
+
+Fields:
+
+* `data`: `String` - data to be encoded as json.
 
 ## Pose
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -1,13 +1,103 @@
-# Messages
+# Messages and data types
 
-This page documents the message structures for the topics used by the components of AeroSim to exchange data.
+This page documents the message and data type structures for the topics used by the components of AeroSim to exchange data. See the [aerosim-data](https://github.com/aerosim-open/aerosim/tree/main/aerosim-data) module for more information.
 
-* [TimeStamp](#timestamp)
-* [VehicleState](#vehiclestate)
-* [FlightControlCommand](#flightcontrolcommand)
+* [ActorState](#actorstate)
 * [AirCraftEffectorCommand](#aircrafteffectorcommand)
 * [AutopilotCommand](#autopilotcommand)
-* [AutopilotFlightPlanCommand](#autopilotflightplancommand)
+* [CompressedImage](#compressedimage)
+* [FlightControlCommand](#flightcontrolcommand)
+* [Pose](#pose)
+* [TimeStamp](#timestamp)
+* [VehicleState](#vehiclestate)
+
+---
+
+## ActorState
+
+Data type with generic actor information.
+
+Fields:
+
+* `pose`: `Pose` - Actor pose
+
+---
+
+## AirCraftEffectorCommand
+
+Fields:
+
+* `throttle_cmd`: *Vec&lt;f64&gt;* - engine throttle command. Scales between 0.0 (no power) and 1.0 (max power). Values are provided in an array for multiple thrust-generating devices.
+* `aileron_cmd_angle_rad`: *Vec&lt;f64&gt;* - aileron deflection command in radians.
+* `elevator_cmd_angle_rad`: *Vec&lt;f64&gt;* - elevator deflection command in radians..
+* `rudder_cmd_angle_rad`: *Vec&lt;f64&gt;* - rudder deflection command in radians..
+* `thrust_tilt_cmd_angle_rad`: *Vec&lt;f64&gt;* - thrust tilt command in radians..
+* `flap_cmd_angle_rad`: *Vec&lt;f64&gt;* -  flap angle in radians.
+* `speedbrake_cmd_angle_rad`: *Vec&lt;f64&gt;* - speedbrake angle in radians
+* `landing_gear_cmd`: *Vec&lt;f64&gt;* - landing gear, 0.0 stowed, 1.0 deployed
+* `wheel_steer_cmd_angle_rad`: *Vec&lt;f64&gt;* - wheel steer angle radians
+* `wheel_brake_cmd`: *Vec&lt;f64&gt;* - wheel brake command, 1.0 fully applied, 0.0 no brake
+
+---
+
+## AutopilotCommand
+
+* `flight_plan`: *String*
+* `flight_plan_command`: *AutopilotFlightPlanCommand*
+* `use_manual_setpoints`: *bool*
+* `attitude_hold`: *bool* - True (hold altitude) or False
+* `altitude_setpoint_ft`: *f64* - target hold altitude
+* `airspeed_hold`: *bool* - True (hold airspeed) or False
+* `airspeed_setpoint_kts`: *f64* - target hold airspeed
+* `heading_hold`: *bool* - True (hold heading) or False
+* `heading_set_by_waypoint`: *bool* - True (use waypoint) or False
+* `heading_setpoint_deg`: *f64* - target heading in degrees
+* `target_wp_latitude_deg`: *f64* - target waypoint latitude
+* `target_wp_longitude_deg`: *f64* - target waypoint longitude
+
+---
+
+## CompressedImage
+
+Data type enconding images from rendered with compression.
+
+Fields:
+
+* `header`: *aerosim_data/msg/Header* - Message header with timeStamp and frame ID information
+* `height`: *uint32* - Height of the image 
+* `width`: *uint32* - Width of the image
+* `format`: *string* - Format of the image
+* `data`: *sequence<uint8>* - Image data as a sequence of integers
+
+---
+
+## FlightControlCommand
+
+Data type used as input to a flight controller, got as output from (auto)pilot.
+
+Fields:
+
+* `power_cmd`: *Vec&lt;f64&gt;* - vehicle power command. Scales between 0.0 (no power) and 1.0 (max power). Values are provided in an array for multiple thrust-generating devices.
+* `roll_cmd`: *f64* - vehicle roll command. Scales between -1.0 and 1.0
+* `pitch_cmd`: *f64* - vehicle pitch command. Scales between -1.0 and 1.0
+* `yaw_cmd`: *f64* - vehicle yaw command. Scales between -1.0 and 1.0
+* `thrust_tilt_cmd`: *f64* - tilt command for a tilt-rotor craft. Scales between 0.0 and 1.0
+* `flap_cmd`: *f64* - flap state command. Scales between 0.0 and 1.0
+* `speedbrake_cmd`: *f64* - speed brake command. Scales between 0.0 and 1.0
+* `landing_gear_cmd`: *f64* - landing gear command. Scales between 0.0 (stowed) amd 1.0 (extended)
+* `wheel_steer_cmd`: *f64* - wheel steer for taxi. Scales between -1.0 (left) and 1.0 (right)
+* `wheel_brake_cmd`: *f64* - wheel brake command. Scales between 0.0 (off) and 1.0 (full strength)
+
+---
+
+## Pose
+
+Data type with position and orientation information of an actor.
+
+Fields:
+
+* `position`: `Vector3` - Actor 3D position
+* `orientation`: `Quaternion` - Actor quaternion orientation
 
 ---
 
@@ -47,76 +137,3 @@ Fields:
     * `x`, `y`, `z`
 * `angular_acceleration`: *Vector3* - actor angular acceleration in rad/s<sup>2</sup>
     * `x`, `y`, `z`
-
----
-
-## FlightControlCommand
-
-Fields:
-
-* `power_cmd`: *Vec&lt;f64&gt;* - vehicle power command. Scales between 0.0 (no power) and 1.0 (max power). Values are provided in an array for multiple thrust-generating devices.
-* `roll_cmd`: *f64* - vehicle roll command. Scales between -1.0 and 1.0
-* `pitch_cmd`: *f64* - vehicle pitch command. Scales between -1.0 and 1.0
-* `yaw_cmd`: *f64* - vehicle yaw command. Scales between -1.0 and 1.0
-* `thrust_tilt_cmd`: *f64* - tilt command for a tilt-rotor craft. Scales between 0.0 and 1.0
-* `flap_cmd`: *f64* - flap state command. Scales between 0.0 and 1.0
-* `speedbrake_cmd`: *f64* - speed brake command. Scales between 0.0 and 1.0
-* `landing_gear_cmd`: *f64* - landing gear command. Scales between 0.0 (stowed) amd 1.0 (extended)
-* `wheel_steer_cmd`: *f64* - wheel steer for taxi. Scales between -1.0 (left) and 1.0 (right)
-* `wheel_brake_cmd`: *f64* - wheel brake command. Scales between 0.0 (off) and 1.0 (full strength)
-
----
-
-## AirCraftEffectorCommand
-
-Fields:
-
-* `throttle_cmd`: *Vec&lt;f64&gt;* - engine throttle command. Scales between 0.0 (no power) and 1.0 (max power). Values are provided in an array for multiple thrust-generating devices.
-* `aileron_cmd_angle_rad`: *Vec&lt;f64&gt;* - aileron deflection command in radians.
-* `elevator_cmd_angle_rad`: *Vec&lt;f64&gt;* - elevator deflection command in radians..
-* `rudder_cmd_angle_rad`: *Vec&lt;f64&gt;* - rudder deflection command in radians..
-* `thrust_tilt_cmd_angle_rad`: *Vec&lt;f64&gt;* - thrust tilt command in radians..
-* `flap_cmd_angle_rad`: *Vec&lt;f64&gt;* -  flap angle in radians.
-* `speedbrake_cmd_angle_rad`: *Vec&lt;f64&gt;* - speedbrake angle in radians
-* `landing_gear_cmd`: *Vec&lt;f64&gt;* - landing gear, 0.0 stowed, 1.0 deployed
-* `wheel_steer_cmd_angle_rad`: *Vec&lt;f64&gt;* - wheel steer angle radians
-* `wheel_brake_cmd`: *Vec&lt;f64&gt;* - wheel brake command, 1.0 fully applied, 0.0 no brake
-
----
-
-## AutopilotCommand
-
-* `flight_plan`: *String*
-* `flight_plan_command`: *AutopilotFlightPlanCommand*
-* `use_manual_setpoints`: *bool*
-* `attitude_hold`: *bool* - True (hold altitude) or False
-* `altitude_setpoint_ft`: *f64* - target hold altitude
-* `airspeed_hold`: *bool* - True (hold airspeed) or False
-* `airspeed_setpoint_kts`: *f64* - target hold airspeed
-* `heading_hold`: *bool* - True (hold heading) or False
-* `heading_set_by_waypoint`: *bool* - True (use waypoint) or False
-* `heading_setpoint_deg`: *f64* - target heading in degrees
-* `target_wp_latitude_deg`: *f64* - target waypoint latitude
-* `target_wp_longitude_deg`: *f64* - target waypoint longitude
-
----
-
-## AutopilotFlightPlanCommand
-
-* `Stop` = 0
-* `Run` = 1
-* `Pause` = 2
-
----
-
-## CompressedImage
-
-Data type enconding images from rendered with compression.
-
-Fields:
-
-* `header`: *aerosim_data/msg/Header* - Message header with timeStamp and frame ID information
-* `height`: *uint32* - Height of the image 
-* `width`: *uint32* - Width of the image
-* `format`: *string* - Format of the image
-* `data`: *sequence<uint8>* - Image data as a sequence of integers

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -7,6 +7,7 @@ This page documents the message and data type structures for the topics used by 
 * [AutopilotCommand](#autopilotcommand)
 * [CompressedImage](#compressedimage)
 * [FlightControlCommand](#flightcontrolcommand)
+* [Image](#image)
 * [Pose](#pose)
 * [Quaternion](#quaternion)
 * [TimeStamp](#timestamp)
@@ -44,32 +45,45 @@ Fields:
 
 ## AutopilotCommand
 
-* `flight_plan`: `string`
-* `flight_plan_command`: `AutopilotFlightPlanCommand`
-* `use_manual_setpoints`: `bool`
-* `attitude_hold`: `bool` - True (hold altitude) or False
-* `altitude_setpoint_ft`: `f64` - Target hold altitude
-* `airspeed_hold`: `bool` - True (hold airspeed) or False
-* `airspeed_setpoint_kts`: `f64` - Target hold airspeed
-* `heading_hold`: `bool` - True (hold heading) or False
-* `heading_set_by_waypoint`: `bool` - True (use waypoint) or False
-* `heading_setpoint_deg`: `f64` - Target heading in degrees
-* `target_wp_latitude_deg`: `f64` - Target waypoint latitude
-* `target_wp_longitude_deg`: `f64` - Target waypoint longitude
+* `flight_plan`: `String` - Flight plan information, e.g. waypoints, mission, etc.
+* `flight_plan_command`: `AutopilotFlightPlanCommand` - Flight plan execution command
+* `use_manual_setpoints`: `bool` - Flag to use manual setpoints instead of flight plan
+* `attitude_hold`: `bool` - Flag to hold current attitude roll/pitch/yaw if True
+* `altitude_setpoint_ft`: `f64` - Target hold altitude in feet
+* `airspeed_hold`: `bool` - Flag to hold airspeed if True
+* `airspeed_setpoint_kts`: `f64` - Target hold airspeed in knots
+* `heading_hold`: `bool` - Flag to hold heading if True
+* `heading_set_by_waypoint`: `bool` - Flag to use waypoint as target heading instead of heading_setpoint if True
+* `heading_setpoint_deg`: `f64` - Target heading setpoint in degrees (0 = north, 90 = east, 180 = south, 270 = west)
+* `target_wp_latitude_deg`: `f64` - Target waypoint latitude in degrees
+* `target_wp_longitude_deg`: `f64` - Target waypoint longitude in degrees
+
+---
+
+## CameraInfo
+
+Data type with information about the camera settings.
+
+Fields:
+
+* `width`: `u32`
+* `height`: `u32`
+* `distortion_model`: `String`
+* `d`: `Vec<f64>`
+* `k`: `[f64; 9]`
+* `r`: `[f64; 9]`
+* `p`: `[f64; 12]`
 
 ---
 
 ## CompressedImage
 
-Data type enconding images from rendered with compression.
+Compressed images from the `Image` data type using [turbojpeg](https://docs.rs/turbojpeg/latest/turbojpeg/) via the method `compress`. Can be decompress to an `Image` type through the `decompress` method. Dimensions of the image are encoded in the compression.
 
 Fields:
 
-* `header`: *aerosim_data/msg/Header* - Message header with timeStamp and frame ID information
-* `height`: `uint32` - Height of the image 
-* `width`: `uint32` - Width of the image
-* `format`: *string* - Format of the image
-* `data`: *sequence<uint8>* - Image data as a sequence of integers
+* `format`: `ImageFormat` - Format of the image, `JPEG` or `PNG`.
+* `data`: `Vec<u8>` - Image data
 
 ---
 
@@ -89,6 +103,29 @@ Fields:
 * `landing_gear_cmd`: `f64` - Landing gear command. Scales between 0.0 (stowed) amd 1.0 (extended)
 * `wheel_steer_cmd`: `f64` - Wheel steer for taxi. Scales between -1.0 (left) and 1.0 (right)
 * `wheel_brake_cmd`: `f64` - Wheel brake command. Scales between 0.0 (off) and 1.0 (full strength)
+
+---
+
+## Image
+
+Data type for encoding images. Can be converted through the `compress` method to a `CompressedImage`.
+
+Fields:
+
+* `camera_info`: `CameraInfo` - Information of the camera source
+* `height`: `u32` - Height of the image
+* `width`: `u32` - Width of the image 
+* `encoding`: `ImageEncoding` - Type of enconding of the image:
+    - `RGB8`
+    - `RGBA8`
+    - `BGR8`
+    - `BGRA8`
+    - `MONO8`
+    - `MONO16`
+    - `YUV422`
+* `is_bigendian`: `u8` - Whether it is big endian or not (order of bytes encoding)
+* `step`: `u32`
+* `data`: `Vec<u8>` - Image data as a sequence of integers
 
 ---
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -3,13 +3,14 @@
 This page documents the message and data type structures for the topics used by the components of AeroSim to exchange data. See the [aerosim-data](https://github.com/aerosim-open/aerosim/tree/main/aerosim-data) module for more information.
 
 * [ActorState](#actorstate)
-* [AirCraftEffectorCommand](#aircrafteffectorcommand)
+* [AircraftEffectorCommand](#aircrafteffectorcommand)
 * [AutopilotCommand](#autopilotcommand)
 * [CameraInfo](#camerainfo)
 * [CompressedImage](#compressedimage)
 * [FlightControlCommand](#flightcontrolcommand)
 * [Image](#image)
 * [Pose](#pose)
+* [PrimaryFlightDisplayData](#primaryflightdisplaydata)
 * [Quaternion](#quaternion)
 * [TimeStamp](#timestamp)
 * [Vector3](#vector3)
@@ -27,7 +28,9 @@ Fields:
 
 ---
 
-## AirCraftEffectorCommand
+## AircraftEffectorCommand
+
+Data type with input to flight dynamics model, output from flight controller.
 
 Fields:
 
@@ -46,8 +49,15 @@ Fields:
 
 ## AutopilotCommand
 
+Input to autopilot.
+
+Fields:
+
 * `flight_plan`: `String` - Flight plan information, e.g. waypoints, mission, etc.
-* `flight_plan_command`: `AutopilotFlightPlanCommand` - Flight plan execution command
+* `flight_plan_command`: `AutopilotFlightPlanCommand` - Flight plan execution command:
+    - `Stop` = 0
+    - `Run` = 1
+    - `Pause` = 2
 * `use_manual_setpoints`: `bool` - Flag to use manual setpoints instead of flight plan
 * `attitude_hold`: `bool` - Flag to hold current attitude roll/pitch/yaw if True
 * `altitude_setpoint_ft`: `f64` - Target hold altitude in feet
@@ -70,10 +80,10 @@ Fields:
 * `width`: `u32` - Width of the camera
 * `height`: `u32` - Height of the camera
 * `distortion_model`: `String` - Distortion model assumed in the camera
-* `d`: `Vec<f64>` - Distortion parameter *d*
-* `k`: `[f64; 9]` - Distortion parameter *k*
-* `r`: `[f64; 9]` - Distortion parameter *r*
-* `p`: `[f64; 12]` - Distortion parameter *p*
+* `d`: `Vec<f64>` - Camera parameter *d*
+* `k`: `[f64; 9]` - Camera parameter *k*
+* `r`: `[f64; 9]` - Camera parameter *r*
+* `p`: `[f64; 12]` - Camera parameter *p*
 
 ---
 
@@ -138,6 +148,31 @@ Fields:
 
 * `position`: `Vector3` - Actor 3D position
 * `orientation`: `Quaternion` - Actor quaternion orientation
+
+---
+
+## PrimaryFlightDisplayData
+
+Flight data to be displayed in the deck's Primary Flight Display (PFD) component.
+
+Fields:
+
+* `airspeed_kts`: `f64` - JSBSim `velocities/vc-kts`
+* `true_airspeed_kts`: `f64` - JSBSim `velocities/vtrue-kts`
+* `altitude_ft`: `f64` - JSBSim `position/h-sl-ft`
+* `target_altitude_ft`: `f64` - AutopilotCommand `altitude_setpoint_ft`
+* `altimeter_pressure_setting_inhg`: `f64` - User-set value (standard pressure = 29.92 inHG, QNH = height above MSL adjusted from local atmospheric pressure, QFE = height above airfield elevation)
+* `vertical_speed_fpm`: `f64` - JSBSim `velocities/h-dot-fps` converted to feet/min
+* `pitch_deg`: `f64` - JSBSim `attitude/pitch-rad`
+* `roll_deg`: `f64` - JSBSim `attitude/roll-rad`
+* `side_slip_fps2`: `f64` - JSBSim `accelerations/vdot-ft_sec2`
+* `heading_deg`: `f64` - JSBSim `attitude/heading-true-rad` converted to deg
+* `hsi_course_select_heading_deg`: `f64` - For GPS mode, calculated heading between prev and next waypoints
+* `hsi_course_deviation_deg`: `f64` - For GPS mode, nautical mile offset from course line converted as 5 NM = 12 deg
+* `hsi_mode`: `HSIMode` - User-set mode, start with GPS only:
+    - `GPS` = 0
+    - `VOR1` = 1
+    - `VOR2` = 2
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,7 @@ nav:
 - Resources:
   - AeroSim app: 'aerosim_app.md'
   - Conventions: 'conventions.md'
-  - Messages: 'messages.md'
+  - Messages and data types: 'messages.md'
   - Simulation config: 'sim_config.md'
   - FMU reference: 'fmu_reference.md'
   - Scene graph: 'scene_graph_reference.md'


### PR DESCRIPTION
Expand messages and data types documentation by including all missing data types considered in AeroSim, improving formatting and expanding descriptions.

Sensor messages:
- [x] Image
- [x] CompressedImage
- [x] GNSS
- [x] IMU
- [x] ImageEncoding
- [x] ImageFormat

Trajectory visualization data types:
- [x] TrajectoryVisualization
- [x] TrajectoryVisualizationSettings
- [x] TrajectoryWaypoints

Other data types added:

- [x] Quaternion
- [x] Vector3
- [x] Pose
- [x] ActorState
- [x] CameraInfo
- [x] PrimaryFlightDisplayData
- [x] Header
- [x] JsonData
- [x] EffectorState
- [x] ActorModel
- [x] PhysicalProperties
- [x] AutopilotFlightPlanCommand
- [x] HSIMode

In addition, remove some unused imports in aerosim.io.